### PR TITLE
Add pdf-image-pack dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "jshint-stylish": "~0.1.5",
     "load-grunt-tasks": "~0.3.0"
   },
+  "dependencies": {
+    "pdf-image-pack": "~0.0.0"
+  },
   "scripts": {
     "test": "grunt test"
   }


### PR DESCRIPTION
Module pdf-image-pack is referenced in tasks/pdf_imagepack.js but it wasn't installed, resulting in

> > Error: Cannot find module 'pdf-image-pack'.  

This adds the dependency to package.json so it's installed by default with grunt-pdf-imagepack.
